### PR TITLE
fixes OpenCL include statements on OS X

### DIFF
--- a/DeviceInfo.cpp
+++ b/DeviceInfo.cpp
@@ -2,15 +2,14 @@
 #include "clew.h"
 #endif
 
-//#ifdef USE_CLEW
-//#include "clew.h"
-//#else
-#include "CL/cl.h"
-//#endif
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
-#include "DeviceInfo.h"
 #include "EasyCL.h"
-//#include "clew.h"
+#include "DeviceInfo.h"
 #include "platforminfo_helper.h"
 #include "deviceinfo_helper.h"
 

--- a/DeviceInfo.h
+++ b/DeviceInfo.h
@@ -3,7 +3,11 @@
 #include <string>
 #include "DeviceInfo.h"
 //#include "clew.h"
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
 #include "EasyCL_export.h"
 

--- a/DevicesInfo.cpp
+++ b/DevicesInfo.cpp
@@ -1,16 +1,19 @@
 #ifdef USE_CLEW
 #include "clew.h"
 #else
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 #endif
 
+#include "EasyCL.h"
+#include "DeviceInfo.h"
+#include "DevicesInfo.h"
 #include "deviceinfo_helper.h"
 #include "platforminfo_helper.h"
 #include <stdexcept>
-#include "EasyCL.h"
-
-#include "DevicesInfo.h"
-#include "DeviceInfo.h"
 
 using namespace std;
 

--- a/DevicesInfo.h
+++ b/DevicesInfo.h
@@ -1,9 +1,12 @@
 #pragma once
 
-//#include "clew.h"
-#include "CL/cl.h"
-#include "DeviceInfo.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
+#include "DeviceInfo.h"
 #include "EasyCL_export.h"
 
 namespace easycl {

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -11,7 +11,11 @@ using namespace std;
 #ifdef USE_CLEW
 #include "clew.h"
 #else
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 #endif
 
 #include "EasyCL.h"

--- a/EasyCL.h
+++ b/EasyCL.h
@@ -9,7 +9,12 @@
 #ifdef USE_CLEW
 #include "clew.h"
 #else
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
+
 #endif
 
 #include <cstdlib>

--- a/deviceinfo_helper.h
+++ b/deviceinfo_helper.h
@@ -9,11 +9,11 @@
 #include <algorithm>
 #include <string>
 
-//#ifdef USE_CLEW
-//#include "clew.h"
-//#else
-#include "CL/cl.h"
-//#endif
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
 #include "mystdint.h"
 

--- a/gpuinfo.cpp
+++ b/gpuinfo.cpp
@@ -12,7 +12,11 @@ using namespace std;
 #ifdef USE_CLEW
 #include "clew.h"
 #else
-#include "CL/cl.h"
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 #endif
 
 #include "deviceinfo_helper.h"

--- a/platforminfo_helper.h
+++ b/platforminfo_helper.h
@@ -9,11 +9,11 @@
 #include <algorithm>
 #include <string>
 
-//#ifdef USE_CLEW
-//#include "clew.h"
-//#else
-#include "CL/cl.h"
-//#endif
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
 void printPlatformInfoString(std::string valuename, cl_platform_id platformId, cl_platform_info name);
 void printPlatformInfo(std::string valuename, cl_platform_id platformId, cl_platform_info name);


### PR DESCRIPTION
Changes most places where `CL/cl.h` is included to the same OSX-aware macro used by clBLAS.
Also removed some redundant includes.