### PR TITLE
Force maxworkgroupsize to no more than 128 on cpus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - make install
   - source ../dist/bin/easycl_activate.sh
   - gpuinfo
-  - easycl_unittests tests=-SLOW*:testlocal*:testnewinstantiations.createForFirstGpu:testnewinstantiations.createForIndexedGpu
+  - easycl_unittests tests=-SLOW*:testnewinstantiations.createForFirstGpu:testnewinstantiations.createForIndexedGpu
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,13 @@ matrix:
       rvm: system
 
 before_install:
-  - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow; fi
+  - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow --quiet; fi
   - whoami
   - pwd
   - ls
-  - git status
-  - ls ~
   - echo $HOME
-  - env
 
 script:
-  - echo hello
-  - env
   - mkdir build
   - cd build
   - cmake .. -DBUILD_TESTS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,8 @@ if(BUILD_TESTS)
       add_library( easycl_gtest thirdparty/gtest/gtest-all.cc )
   endif()
 
-  add_executable( easycl_unittests test/testscalars.cpp test/testintarray.cpp test/testfloatwrapper.cpp
+  add_executable( easycl_unittests test/testworkgroupsize.cpp
+      test/testscalars.cpp test/testintarray.cpp test/testfloatwrapper.cpp
       test/testclarray.cpp test/testfloatwrapperconst.cpp test/testintwrapper.cpp test/test_scenario_te42kyfo.cpp
       test/testfloatarray.cpp test/testeasycl.cpp test/testinout.cpp test/testintwrapper_huge.cpp
       test/testlocal.cpp test/testdefines.cpp test/testbuildlog.cpp test/testnewinstantiations.cpp

--- a/DeviceInfo.cpp
+++ b/DeviceInfo.cpp
@@ -37,7 +37,7 @@ namespace easycl {
 
         // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
         if(deviceType == 2) {  
-            maxWorkGroupSize > 128 ? 128 : maxWorkGroupSize;
+            maxWorkGroupSize = maxWorkGroupSize > 128 ? 128 : maxWorkGroupSize;
         }
     }
 

--- a/DeviceInfo.cpp
+++ b/DeviceInfo.cpp
@@ -34,6 +34,11 @@ namespace easycl {
         openClCVersion = getDeviceInfoString(deviceId, CL_DEVICE_OPENCL_C_VERSION);
         deviceVersion = getDeviceInfoString(deviceId, CL_DEVICE_VERSION);
         maxClockFrequency = getDeviceInfoInt(deviceId, CL_DEVICE_MAX_CLOCK_FREQUENCY);
+
+        // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
+        if(deviceType == 2) {  
+            maxWorkGroupSize > 128 ? 128 : maxWorkGroupSize;
+        }
     }
 
     string DeviceInfo::toString() {

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -511,7 +511,13 @@ int EasyCL::getLocalMemorySizeKB() {
     return (int)(this->getDeviceInfoInt64(CL_DEVICE_LOCAL_MEM_SIZE) / 1024);
 }
 int EasyCL::getMaxWorkgroupSize() {
-    return (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
+    int maxWorkgroupSize = (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
+    int deviceType = getDeviceInfoInt(deviceId, CL_DEVICE_TYPE);
+    if(deviceType == 2) {  // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
+        return maxWorkgroupSize > 128 ? 128 : maxWorkgroupSize;
+    } else {
+        return maxWorkgroupSize;
+    }
 }
 int EasyCL::getMaxAllocSizeMB() {
     return (int)(this->getDeviceInfoInt64(CL_DEVICE_MAX_MEM_ALLOC_SIZE) / 1024 / 1024);

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -513,6 +513,7 @@ int EasyCL::getLocalMemorySizeKB() {
 int EasyCL::getMaxWorkgroupSize() {
     int maxWorkgroupSize = (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
     int deviceType = this->getDeviceInfoInt(CL_DEVICE_TYPE);
+    cout << "EasyCL::getMaxWorkgroupSize() deviceType=" << deviceType << " mws=" << maxWorkgroupSize << endl;
     if(deviceType == 2) {  // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
         return maxWorkgroupSize > 128 ? 128 : maxWorkgroupSize;
     } else {

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -512,7 +512,7 @@ int EasyCL::getLocalMemorySizeKB() {
 }
 int EasyCL::getMaxWorkgroupSize() {
     int maxWorkgroupSize = (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
-    int deviceType = getDeviceInfoInt(deviceId, CL_DEVICE_TYPE);
+    int deviceType = this->getDeviceInfoInt(CL_DEVICE_TYPE);
     if(deviceType == 2) {  // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
         return maxWorkgroupSize > 128 ? 128 : maxWorkgroupSize;
     } else {
@@ -562,6 +562,12 @@ int64_t EasyCL::getDeviceInfoInt64(cl_device_info name) {
     cl_ulong value = 0;
     clGetDeviceInfo(device, name, sizeof(cl_ulong), &value, 0);
     return static_cast<int64_t>(value);
+}
+
+int EasyCL::getDeviceInfoInt(cl_device_info name) {
+    cl_uint value = 0;
+    clGetDeviceInfo(device, name, sizeof(cl_uint), &value, 0);
+    return static_cast<int>(value);
 }
 
 void EasyCL::storeKernel(std::string name, CLKernel *kernel) {

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -512,7 +512,8 @@ int EasyCL::getLocalMemorySizeKB() {
 }
 int EasyCL::getMaxWorkgroupSize() {
     int maxWorkgroupSize = (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
-    int deviceType = this->getDeviceInfoInt(CL_DEVICE_TYPE);
+    cl_device_type deviceType;
+    clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(cl_device_type), &deviceType, 0);
     cout << "EasyCL::getMaxWorkgroupSize() deviceType=" << deviceType << " mws=" << maxWorkgroupSize << endl;
     if(deviceType == 2) {  // hack for intel cpus, which return workgroupsize 1024, but only support 128 (eg Xeon X5570, on Apple Mac)
         return maxWorkgroupSize > 128 ? 128 : maxWorkgroupSize;

--- a/EasyCL.h
+++ b/EasyCL.h
@@ -146,6 +146,7 @@ private:
     static std::string getFileContents(std::string filename);
 //    long getDeviceInfoInt(cl_device_info name);
     int64_t getDeviceInfoInt64(cl_device_info name);
+    int getDeviceInfoInt(cl_device_info name);
 };
 
 #include "CLIntWrapper.h"

--- a/test/testlocal.cpp
+++ b/test/testlocal.cpp
@@ -43,6 +43,7 @@ TEST(testlocal, globalreduce) {
     EasyCL *cl = EasyCL::createForFirstGpuOtherwiseCpu();
     CLKernel *kernel = cl->buildKernelFromString(getKernel(), "reduceGlobal", "");
     int workgroupSize = min(512, cl->getMaxWorkgroupSize());
+    cout << "workgroupSize=" << workgroupSize << " cl->getMaxWorkgroupSize() = " << cl->getMaxWorkgroupSize() << endl;
     float *myarray = new float[workgroupSize];
 //    Timer timer;
     for(int i = 0; i < 2000; i++) {

--- a/test/testworkgroupsize.cpp
+++ b/test/testworkgroupsize.cpp
@@ -1,0 +1,108 @@
+#include <iostream>
+#include <cstdlib>
+// using namespace std;
+
+#include "gtest/gtest.h"
+
+#include "EasyCL.h"
+
+#include "test/asserts.h"
+
+using namespace std;
+
+static const char *getKernel();
+
+TEST(testworkgroupsize, main) {
+    if(!EasyCL::isOpenCLAvailable()) {
+        cout << "opencl library not found" << endl;
+        exit(-1);
+    }
+    cout << "found opencl library" << endl;
+
+    EasyCL *cl = EasyCL::createForFirstGpuOtherwiseCpu();
+    CLKernel *kernel = cl->buildKernelFromString(getKernel(), "test", "");
+    int maxWorkgroupSize = cl->getMaxWorkgroupSize();
+    cout << "max workgroup size: " << maxWorkgroupSize << endl;
+    for(int workgroupSize = 16; workgroupSize <= maxWorkgroupSize; workgroupSize <<= 1 ) {
+        float *in = new float[workgroupSize];
+        float *out = new float[workgroupSize];
+        for(int i = 0; i < workgroupSize; i++) {
+            in[i] = i * 3;
+        }
+        CLWrapper *inwrapper = cl->wrap(workgroupSize, in);
+        CLWrapper *outwrapper = cl->wrap(workgroupSize, out);
+        inwrapper->copyToDevice();
+        kernel->input(inwrapper);
+        kernel->output(outwrapper);
+        kernel->run_1d(workgroupSize, workgroupSize);
+        outwrapper->copyToHost();
+        for(int i = 0; i < workgroupSize; i+= (workgroupSize / 8)) {
+            assertEquals(out[i] , (i + 2) * 3 + 1);
+        }
+        cout << "tests completed ok for workgroupSize " << workgroupSize << endl;
+        delete[] in;
+        delete[] out;
+        delete inwrapper;
+        delete outwrapper;
+    }
+
+    delete kernel;
+    delete cl;
+}
+
+static const char *getKernel() {
+    // [[[cog
+    // import stringify
+    // stringify.stringify("source", "test/testeasycl.cl")
+    // ]]]
+    // generated using cog, from test/testeasycl.cl:
+    const char * source =  
+    "kernel void test(global float *in, global float *out) {\n" 
+    "    const int globalid = get_global_id(0);\n" 
+    "    out[globalid] = in[globalid] + 7;\n" 
+    "}\n" 
+    "\n" 
+    "kernel void testuchars(global unsigned char *in, global unsigned char *out) {\n" 
+    "    const int globalid = get_global_id(0);\n" 
+    "    out[globalid] = in[globalid] + 7;\n" 
+    "}\n" 
+    "\n" 
+    "kernel void test_int(global int *in, global int *out) {\n" 
+    "    const int globalid = get_global_id(0);\n" 
+    "    out[globalid] = in[globalid] + 7;\n" 
+    "}\n" 
+    "\n" 
+    "kernel void test_stress(global const int *in, global int *out) {\n" 
+    "    const int globalid = get_global_id(0);\n" 
+    "    int sum = 0;\n" 
+    "    int n = 0;\n" 
+    "   // make it do some work....\n" 
+    "//    while(n < 1000000) {\n" 
+    "    while(n < 10001) {\n" 
+    "        sum = (sum + in[n % 47]) % (103070 * 7);\n" 
+    "        n++;\n" 
+    "    }\n" 
+    "    out[globalid] = sum;\n" 
+    "}\n" 
+    "\n" 
+    "kernel void test_read(const int one,  const int two, global int *out) {\n" 
+    "    const int globalid = get_global_id(0);\n" 
+    "    int sum = 0;\n" 
+    "    int n = 0;\n" 
+    "    while(n < 100000) {\n" 
+    "        sum = (sum + one) % 1357 * two;\n" 
+    "        n++;\n" 
+    "    }\n" 
+    "//    out[globalid+2048] = sum;\n" 
+    "//    out[globalid] = sum;\n" 
+    "//    out[0] = 44;\n" 
+    "    out[globalid] = sum;\n" 
+    "   // out[0] = globalid > out[0] ? globalid : out[0];\n" 
+    "//    out[globalid] = 8827;\n" 
+    "}\n" 
+    "\n" 
+    "";
+    // [[[end]]]
+    return source;
+}
+


### PR DESCRIPTION
Force maxworkgroupsize to no more than 128 on cpus, because some Intel CPUs report maxworkgroupsize 1024, which will fail. (Note: seems problem is specific to Mac OS X actually https://github.com/clMathLibraries/clBLAS/issues/25 )