### PR TITLE
Made CLKernel::run* behave the same with and without output, cache results that never change, and added getPreferredWorkGroupSizeMultiple

### DIFF
--- a/CLKernel.cpp
+++ b/CLKernel.cpp
@@ -392,6 +392,22 @@ void CLKernel::run(cl_command_queue *queue, int ND, const size_t *global_ws, con
     nextArg = 0;
 }
 
+int CLKernel::getPreferredWorkGroupSizeMultiple()
+{
+    if (preferredMultiple != -1)
+        return preferredMultiple;
+
+    size_t value;
+    error = clGetKernelWorkGroupInfo(kernel, cl->device, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, sizeof(size_t), &value, NULL);
+
+    if (error != CL_SUCCESS)
+    {
+        cl->checkError(error);
+    }
+
+    return preferredMultiple = (int)value;
+}
+
 // template class std::vector<cl_mem>;
 
 #define EASYCL_INSTANTIATE_FOR_TYPE(TYPE) \

--- a/CLKernel.cpp
+++ b/CLKernel.cpp
@@ -366,7 +366,7 @@ void CLKernel::run(cl_command_queue *queue, int ND, const size_t *global_ws, con
 
     //void retrieveresultsandcleanup() {
     for (int i = 0; i < (int)outputArgBuffers.size(); i++) {
-        clEnqueueReadBuffer(*(queue), outputArgBuffers[i], CL_TRUE, 0, outputArgSizes[i], outputArgPointers[i], 0, NULL, NULL);
+        clEnqueueReadBuffer(*(queue), outputArgBuffers[i], CL_FALSE, 0, outputArgSizes[i], outputArgPointers[i], 0, NULL, NULL);
     }
     //        std::cout << "done" << std::endl;
 
@@ -377,6 +377,7 @@ void CLKernel::run(cl_command_queue *queue, int ND, const size_t *global_ws, con
     for(int i = 0; i < (int)wrappersToDirty.size(); i++) {
         wrappersToDirty[i]->markDeviceDirty();
     }
+    cl->finish();
     buffers.clear();
     outputArgBuffers.clear();
     outputArgPointers.clear();

--- a/CLKernel.h
+++ b/CLKernel.h
@@ -19,6 +19,7 @@ class CLQueue;
 
 class EasyCL_EXPORT CLKernel {
     EasyCL *cl; // NOT owned by this object, dont delete!
+    int preferredMultiple = -1;
 #ifdef _WIN32
 #pragma warning(disable: 4251)
 #endif
@@ -132,6 +133,7 @@ public:
     void run(int ND, const size_t *global_ws, const size_t *local_ws);
     void run(cl_command_queue *queue, int ND, const size_t *global_ws, const size_t *local_ws);
     void run(CLQueue *queue, int ND, const size_t *global_ws, const size_t *local_ws);
+    int getPreferredWorkGroupSizeMultiple();
 
     std::string buildLog;
 };

--- a/CLWrapper.cpp
+++ b/CLWrapper.cpp
@@ -74,7 +74,7 @@ void CLWrapper::copyToHost() {
     error = clEnqueueReadBuffer(*(cl->queue), devicearray, CL_TRUE, 0, getElementSize() * N, getHostArray(), 0, NULL, NULL);    
     cl->checkError(error);
     if (error != CL_SUCCESS) {
-        throw std::runtime_error("wait for event on copytohost failed with " + easycl::toString(err) );
+        throw std::runtime_error("clEnqueueReadBuffer failed with " + easycl::toString(error) );
     }
     deviceDirty = false;
 }

--- a/CLWrapper.cpp
+++ b/CLWrapper.cpp
@@ -88,7 +88,7 @@ void CLWrapper::copyToDevice() {
     if(!onDevice) {
         createOnDevice();
     }
-    error = clEnqueueWriteBuffer(*(cl->queue), devicearray, CL_TRUE, 0, getElementSize() * N, getHostArrayConst(), 0, NULL, NULL);    
+    error = clEnqueueWriteBuffer(*(cl->queue), devicearray, CL_FALSE, 0, getElementSize() * N, getHostArrayConst(), 0, NULL, NULL);    
     cl->checkError(error);
     deviceDirty = false;
 }

--- a/CLWrapper.cpp
+++ b/CLWrapper.cpp
@@ -71,12 +71,9 @@ void CLWrapper::copyToHost() {
         throw std::runtime_error("copyToHost(): not on device");
     }
 //    cl->finish();
-    cl_event event = NULL;
-    error = clEnqueueReadBuffer(*(cl->queue), devicearray, CL_TRUE, 0, getElementSize() * N, getHostArray(), 0, NULL, &event);    
+    error = clEnqueueReadBuffer(*(cl->queue), devicearray, CL_TRUE, 0, getElementSize() * N, getHostArray(), 0, NULL, NULL);    
     cl->checkError(error);
-    cl_int err = clWaitForEvents(1, &event);
-    clReleaseEvent(event);
-    if (err != CL_SUCCESS) {
+    if (error != CL_SUCCESS) {
         throw std::runtime_error("wait for event on copytohost failed with " + easycl::toString(err) );
     }
     deviceDirty = false;

--- a/CLWrapper.cpp
+++ b/CLWrapper.cpp
@@ -88,7 +88,7 @@ void CLWrapper::copyToDevice() {
     if(!onDevice) {
         createOnDevice();
     }
-    error = clEnqueueWriteBuffer(*(cl->queue), devicearray, CL_FALSE, 0, getElementSize() * N, getHostArrayConst(), 0, NULL, NULL);    
+    error = clEnqueueWriteBuffer(*(cl->queue), devicearray, CL_TRUE, 0, getElementSize() * N, getHostArrayConst(), 0, NULL, NULL);    
     cl->checkError(error);
     deviceDirty = false;
 }

--- a/EasyCL.cpp
+++ b/EasyCL.cpp
@@ -543,19 +543,19 @@ void EasyCL::dumpProfiling() {
   profilingEvents.clear();
 }
 int EasyCL::getComputeUnits() {
-    return (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_COMPUTE_UNITS);
+    return computeUnits != -1 ? computeUnits : computeUnits = (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_COMPUTE_UNITS);
 }
 int EasyCL::getLocalMemorySize() {
-    return (int)this->getDeviceInfoInt64(CL_DEVICE_LOCAL_MEM_SIZE);
+    return localMemorySize != -1 ? localMemorySize : localMemorySize = (int)this->getDeviceInfoInt64(CL_DEVICE_LOCAL_MEM_SIZE);
 }
 int EasyCL::getLocalMemorySizeKB() {
-    return (int)(this->getDeviceInfoInt64(CL_DEVICE_LOCAL_MEM_SIZE) / 1024);
+    return localMemorySizeKB != -1 ? localMemorySizeKB : localMemorySizeKB = (int)(getLocalMemorySize() / 1024);
 }
 int EasyCL::getMaxWorkgroupSize() {
-    return (int)this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE);
+    return maxWorkgroupSize != -1 ? maxWorkgroupSize : maxWorkgroupSize = (int)(this->getDeviceInfoInt64(CL_DEVICE_MAX_WORK_GROUP_SIZE));
 }
 int EasyCL::getMaxAllocSizeMB() {
-    return (int)(this->getDeviceInfoInt64(CL_DEVICE_MAX_MEM_ALLOC_SIZE) / 1024 / 1024);
+    return maxAllocSizeMB != -1 ? maxAllocSizeMB : maxAllocSizeMB = (int)(this->getDeviceInfoInt64(CL_DEVICE_MAX_MEM_ALLOC_SIZE) / 1024 / 1024);
 }
 
 std::string EasyCL::errorMessage(cl_int error) {

--- a/EasyCL.h
+++ b/EasyCL.h
@@ -60,7 +60,7 @@ class EasyCL_EXPORT EasyCL {
 private:
     int maxWorkgroupSize = -1;
     int localMemorySizeKB = -1;
-    int localMemorySize = -1
+    int localMemorySize = -1;
     int maxAllocSizeMB = -1;
     int computeUnits = -1;
 public:

--- a/EasyCL.h
+++ b/EasyCL.h
@@ -57,6 +57,12 @@ public:
 };
 
 class EasyCL_EXPORT EasyCL {
+private:
+    int maxWorkgroupSize = -1;
+    int localMemorySizeKB = -1;
+    int localMemorySize = -1
+    int maxAllocSizeMB = -1;
+    int computeUnits = -1;
 public:
     bool verbose;
 


### PR DESCRIPTION
**CLKernel**

- When there was output it would wait for the kernel to finish then read one output at a time then return. When there was no output it returned "instantly". Now it queues it to read all output(s) (if there are any) then wait for the queue to finish. Giving the same behavior both with and without output(s)
- Added a function to get the preferred work group size multiple

**CLWrapper**

- Since the read is blocking it's unnecessary to create and wait for an event when it wont return until it's done anyways. Therefor I removed it

**EasyCL**
- Cached results that will never change